### PR TITLE
Rendered Card Update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ const sampleCorkBoard = [
             title: "fred",
             description: "also fred",
             priority: "high",
-            thumbColor: "red"
+            thumbColor: "red",
+            assigned: ["Definitely Fred", "Dr. Harvey"]
         },
         id: 1,
         height: 100,
@@ -26,7 +27,8 @@ const sampleCorkBoard = [
             title: "burt",
             description: "also burt",
             priority: "low",
-            thumbColor: "green"
+            thumbColor: "green",
+            assigned: ["I'm doing it all myself"]
         },
         id: 2,
         height: 80,

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -37,7 +37,8 @@ export function Card(inputTask: Task): JSX.Element {
                         description:
                             "This is to show that we can change a full task! This could be input from the user!",
                         priority: "4",
-                        thumbColor: "yellow"
+                        thumbColor: "yellow",
+                        assigned: ["Someone"]
                     })
                 }
             >

--- a/src/components/CardComp.tsx
+++ b/src/components/CardComp.tsx
@@ -22,10 +22,12 @@ function CardComp({
         item: { type: ItemTypes.Card, id: id }
     });
 
+    const assi = task.assigned.join(", ");
+
     return (
         <div>
             <Card
-                style={{ width: "15rem" }}
+                style={{ width: "12rem", backgroundColor: task.thumbColor }}
                 //ref makes the dragging of the Card Work
                 ref={drag}
             >
@@ -46,7 +48,7 @@ function CardComp({
                     <Card.Title>{task.title}</Card.Title>
                     <Card.Text>{task.description}</Card.Text>
                     <Card.Text>Priority: {task.priority}</Card.Text>
-                    <Card.Text>Thumbtack Color: {task.thumbColor}</Card.Text>
+                    <Card.Text>Assignees: {assi}</Card.Text>
                 </Card.Body>
             </Card>
         </div>

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -56,7 +56,8 @@ export function CardList(): JSX.Element {
             title: inTask.title,
             description: inTask.description,
             priority: inTask.priority,
-            thumbColor: inTask.thumbColor
+            thumbColor: inTask.thumbColor,
+            assigned: inTask.assigned
         };
         const tmp: cardData[] = currList.map(
             (cardData: cardData): cardData => ({ ...cardData })

--- a/src/components/CorkBoard.test.tsx
+++ b/src/components/CorkBoard.test.tsx
@@ -8,7 +8,8 @@ const testNote = [
             title: "Complete CISC 275 Project",
             description: "Just do it",
             priority: "medium",
-            thumbColor: "purple"
+            thumbColor: "purple",
+            assigned: ["Fred"]
         },
         id: 1,
         height: 50,
@@ -25,7 +26,8 @@ const testNotes = [
             title: "Complete CISC 275 Project",
             description: "Just do it",
             priority: "medium",
-            thumbColor: "purple"
+            thumbColor: "purple",
+            assigned: ["Fred"]
         },
         id: 1,
         height: 50,
@@ -40,7 +42,8 @@ const testNotes = [
             description:
                 "I need to walk my dog if I don't walk him he will be sad so I should do that",
             priority: "high",
-            thumbColor: "yellow"
+            thumbColor: "yellow",
+            assigned: ["Fredling"]
         },
         id: 2,
         height: 80,
@@ -54,7 +57,8 @@ const testNotes = [
             title: "Perform open heart surgery",
             description: "It's filthy in there",
             priority: "low",
-            thumbColor: "red"
+            thumbColor: "red",
+            assigned: ["Medic TF2"]
         },
         id: 3,
         height: 50,

--- a/src/components/CorkBoard.tsx
+++ b/src/components/CorkBoard.tsx
@@ -19,7 +19,8 @@ export function CorkBoard({
                     title: "fred",
                     description: "also fred",
                     priority: "high",
-                    thumbColor: "red"
+                    thumbColor: "red",
+                    assigned: ["freddy"]
                 },
                 50,
                 75,

--- a/src/components/EditCard.tsx
+++ b/src/components/EditCard.tsx
@@ -21,6 +21,8 @@ export function EditCard({
 
     // state that holds the title the user input
     const [title, setTitle] = useState(task.title);
+    // state that holds the list of assignees
+    const [assignees, setAssi] = useState([""]);
     // state that holds the description the user input
     const [description, setDesc] = useState(task.description);
     // state that holds the color the user selected
@@ -29,7 +31,7 @@ export function EditCard({
     const [priority, setPriority] = useState(task.priority);
 
     // list of colors the user can select
-    const colors = ["red", "pink", "orange", "blue", "black"];
+    const colors = ["Coral", "Pink", "Orange", "Moccasin", "Plum"];
     // list of colors the user can select
     const priorities = ["low", "medium", "high"];
 
@@ -49,6 +51,11 @@ export function EditCard({
     // function that handles a color being selected
     const colorHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
         setColor(event.target.value);
+    };
+
+    const assiHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const assi = event.target.value.split(",");
+        setAssi(assi);
     };
 
     // function that handles a priority being selected
@@ -75,7 +82,8 @@ export function EditCard({
             title: title,
             description: description,
             priority: priority,
-            thumbColor: color
+            thumbColor: color,
+            assigned: assignees
         });
     };
 
@@ -150,6 +158,15 @@ export function EditCard({
                                     />
                                 </>
                             ))}
+                        </Form.Group>
+                        <Form.Group className="makeNoteAssi">
+                            <Form.Label>Assignees</Form.Label>
+                            <Form.Control
+                                as="textarea"
+                                rows={2}
+                                value={assignees}
+                                onChange={assiHandler}
+                            />
                         </Form.Group>
                     </Form>
                 </Modal.Body>

--- a/src/components/MakeNote.tsx
+++ b/src/components/MakeNote.tsx
@@ -136,7 +136,7 @@ export function MakeNote({
                             ))}
                         </Form.Group>
                         <Form.Group className="makeNoteAssi">
-                            <Form.Label>Assignes</Form.Label>
+                            <Form.Label>Assignees</Form.Label>
                             <Form.Control
                                 as="textarea"
                                 rows={2}

--- a/src/components/MakeNote.tsx
+++ b/src/components/MakeNote.tsx
@@ -4,15 +4,6 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import Modal from "react-bootstrap/Modal";
 
-/*
-export let globalNote: Task = {
-    title: "p",
-    description: "",
-    priority: "",
-    thumbColor: ""
-};
-*/
-
 export function MakeNote({
     // input parameter from CardList ; Used for the creating of card so that it gets added to CardList
     addCard
@@ -22,14 +13,16 @@ export function MakeNote({
     const [show, setShow] = useState(false);
     const [title, setTitle] = useState("");
     const [description, setDesc] = useState("");
+    const [assignees, setAssi] = useState([""]);
     //FIXME: Use color to set thumbtack color when modal is made
     const [color, setColor] = useState("red");
-    const colors = ["red", "pink", "orange", "blue", "black"];
+    const colors = ["Coral", "Pink", "Orange", "Moccasin", "Plum"];
     const [newNote, setNote] = useState({
         title: "placeholder",
         description: "",
         priority: "low",
-        thumbColor: "red"
+        thumbColor: "red",
+        assigned: ["Pla", "Ce", "Holder"]
     });
 
     const [priority, setPriority] = useState("low");
@@ -54,21 +47,26 @@ export function MakeNote({
         setDesc(event.target.value);
     };
 
+    const assiHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const assi = event.target.value.split(",");
+        setAssi(assi);
+    };
+
     const createNote = () => {
         setNote({
             title: title,
             description: description,
             priority: priority,
-            thumbColor: color
+            thumbColor: color,
+            assigned: assignees
         });
-        handleClose();
-
-        // Calls the function passed in from CardList to add the created card to CardList
+        handleClose(); // Calls the function passed in from CardList to add the created card to CardList
         addCard({
             title: title,
             description: description,
             priority: priority,
-            thumbColor: color
+            thumbColor: color,
+            assigned: assignees
         });
         console.log(newNote);
         //globalNote = newNote;
@@ -136,6 +134,15 @@ export function MakeNote({
                                     />
                                 </>
                             ))}
+                        </Form.Group>
+                        <Form.Group className="makeNoteAssi">
+                            <Form.Label>Assignes</Form.Label>
+                            <Form.Control
+                                as="textarea"
+                                rows={2}
+                                value={assignees}
+                                onChange={assiHandler}
+                            />
                         </Form.Group>
                     </Form>
                 </Modal.Body>

--- a/src/interfaces/task.ts
+++ b/src/interfaces/task.ts
@@ -9,4 +9,5 @@ export interface Task {
     //set as a string, but should be chosen from a pre-made list of colors (the default HTML/CSS colors)
     //color of the thumbtack when it's stuck to the corkboard
     thumbColor: string;
+    assigned: string[];
 }


### PR DESCRIPTION
Summary of New Stuff:
- Cards have background colors
- Cards no longer show thumbtack color as text
- Cards have a list of assignees
- New colors chosen to avoid eyestrain
- Make Note button accepts a list of assignees and separates them upon rendering the card
- Went through each file and updated each use of the Task interface for reflect the new attribute
- All changes rebased upon editable cards, tested and compatible
- Changed a typo with 'assignes' -> 'assignees'